### PR TITLE
Publishing SWC type declaration for TypeScript, handling non-existent SWC entries.

### DIFF
--- a/swcregistry/__tests__/index.test.ts
+++ b/swcregistry/__tests__/index.test.ts
@@ -1,24 +1,61 @@
 import { SWC } from '../src';
 
-describe('Checking SWC class methods', () => {
+describe('Checking SWC class methods with valid SWC code', () => {
     it('should get title of SWC', () => {
         const swc = new SWC('SWC-100');
         const title = swc.title();
+
         expect(title).toBe('Function Default Visibility');
     });
+
     it('should get relationships of SWC', () => {
         const swc = new SWC('SWC-100')
         const relationships = swc.relationships();
+
         expect(relationships).toBe('[CWE-710: Improper Adherence to Coding Standards](https://cwe.mitre.org/data/definitions/710.html)');
     });
+
     it('should get description of SWC', () => {
         const swc = new SWC('SWC-100')
         const description = swc.description();
+
         expect(description).toBe('Functions that do not have a function visibility type specified are `public` by default. This can lead to a vulnerability if a developer forgot to set the visibility and a malicious user is able to make unauthorized or unintended state changes.');
     });
-    it('should get title of SWC', () => {
+
+    it('should get remediation of SWC', () => {
         const swc = new SWC('SWC-100')
         const remediation = swc.remediation();
+
         expect(remediation).toBe('Functions can be specified as being `external`, `public`, `internal` or `private`. It is recommended to make a conscious decision on which visibility type is appropriate for a function. This can dramatically reduce the attack surface of a contract system.');
+    });
+});
+
+describe('Checking SWC class methods with invalid SWC code', () => {
+    it('should get NULL as title of SWC if there is no entry', () => {
+        const swc = new SWC('SWC-000');
+        const title = swc.title();
+
+        expect(title).toBe(null);
+    });
+
+    it('should get NULL as relationships of SWC if there is no entry', () => {
+        const swc = new SWC('SWC-000')
+        const relationships = swc.relationships();
+
+        expect(relationships).toBe(null);
+    });
+
+    it('should get NULL as description of SWC if there is no entry', () => {
+        const swc = new SWC('SWC-000')
+        const description = swc.description();
+
+        expect(description).toBe(null);
+    });
+
+    it('should get NULL as remediation of SWC if there is no entry', () => {
+        const swc = new SWC('SWC-000')
+        const remediation = swc.remediation();
+
+        expect(remediation).toBe(null);
     });
 });

--- a/swcregistry/package.json
+++ b/swcregistry/package.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "repository": "SmartContractSecurity/SWC-registry-javascript",
     "main": "lib/index.js",
-    "types": "src/index.ts",
+    "types": "lib/index.d.ts",
     "keywords": [
         "swcregistry",
         "npm",

--- a/swcregistry/src/index.ts
+++ b/swcregistry/src/index.ts
@@ -4,6 +4,7 @@ import { XMLHttpRequest } from 'xmlhttprequest-ts';
 import fs = require('fs');
 import fetch = require('node-fetch');
 import path = require('path');
+
 const rawdata = require('./swc-definition.json');
 
 const dirString = path.dirname(fs.realpathSync(__filename));
@@ -27,8 +28,9 @@ class SWC {
     */
   private SWCID: string;
   private rawdata: JSON;
+
   constructor(SWCID) {
-    this.SWCID = SWCID;
+    this.SWCID   = SWCID;
     this.rawdata = rawdata;
   }
 
@@ -54,17 +56,33 @@ class SWC {
       .catch(err => done(err));
   }
 
+  private entry() {
+    return this.rawdata[this.SWCID];
+  }
+
   public title() {
-    return this.rawdata[this.SWCID]['content']['Title'];
+    const entry = this.entry();
+
+    return entry ? entry['content']['Title'] : null;
   }
+
   public relationships() {
-    return this.rawdata[this.SWCID]['content']['Relationships'];
+    const entry = this.entry();
+
+    return entry ? entry['content']['Relationships'] : null;
   }
+
   public description() {
-    return this.rawdata[this.SWCID]['content']['Description'];
+    const entry = this.entry();
+
+    return entry ? entry['content']['Description'] : null;
   }
+
   public remediation() {
-    return this.rawdata[this.SWCID]['content']['Remediation'];
+    const entry = this.entry();
+
+    return entry ? entry['content']['Remediation'] : null;
   }
 }
+
 export { SWC };

--- a/swcregistry/tsconfig.json
+++ b/swcregistry/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": "src/",
     "lib": ["es5", "es6", "dom"],
+    "declaration": true,
     "outDir": "lib/",
     "paths": {
       "@src/*": ["src/*"],


### PR DESCRIPTION
Changed configuration to publish SWC type declaration for TypeScript and resolve [issue 18](https://github.com/SmartContractSecurity/SWC-registry-javascript/issues/18).

Also, handled situation when non-existent SWCID was passed to constructor: now getters will return NULL instead of failing with error. Tweaked getters test to check behavior for non-existent SWC entry.