### PR TITLE
Added index.d.ts to files whitelist of package.json

### DIFF
--- a/swcregistry/package.json
+++ b/swcregistry/package.json
@@ -13,6 +13,7 @@
     ],
     "files": [
         "lib/index.js",
+        "lib/index.d.ts",
         "lib/swc-definition.json"
     ],
     "devDependencies": {


### PR DESCRIPTION
I have forgoten to add type declaration file to package.json, so it was blacklisted and not included to package installation. This PR is an attempt to fix missing `index.d.ts` on installation.

Maintainers, please revise.